### PR TITLE
Update travis push stage to update a branch tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,5 @@ jobs:
         - export TAG=$(git rev-parse --short ${TRAVIS_COMMIT})
         - docker login --password "$QUAY_PASSWORD" --username "$QUAY_USERNAME" quay.io
         - make setup docker-build-and-push TAG=$TAG
-        - docker tag quay.io/integreatly/3scale-operator:$TAG quay.io/integreatly/3scale-operator:$BRANCH
-        - docker push quay.io/integreatly/3scale-operator:$BRANCH
+        - docker tag quay.io/integreatly/$OPERATOR_NAME:$TAG quay.io/integreatly/$OPERATOR_NAME:$BRANCH
+        - docker push quay.io/integreatly/$OPERATOR_NAME:$BRANCH

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: 3scale-operator
       containers:
         - name: 3scale-operator
-          image: quay.io/integreatly/3scale-operator:0.0.4
+          image: quay.io/integreatly/3scale-operator:master
           ports:
           - containerPort: 60000
             name: metrics


### PR DESCRIPTION
## Motivation
This change allows a tag with the same name as the current branch (e.g. master) to be be created/updated when a branch is updated.

Main reason for this is so we can have a "master" tag always kept up to date when a PR is merged back.

## Verification Steps
* Ensure a tag is created/updated for this branch in quay.io https://quay.io/repository/integreatly/3scale-operator

